### PR TITLE
Fixes silveryferret's AI sprite.

### DIFF
--- a/config/custom_sprites.txt
+++ b/config/custom_sprites.txt
@@ -6,7 +6,7 @@ crushtoe:Angelisk
 atlantiscze:AngelOS
 mechoid-Acheron 7*
 donofnyc3-N.O.S.E.
-silveryferret-Nikita
+silveryferret:Nikita
 pear120-Angel
 papadrow-Minerva
 morguemeat-Shudder


### PR DESCRIPTION
- It was added to config file as cyborg sprite, causing him to become invisible when joining as cyborg as it's meant to be AI sprite only.
