### PR TITLE
Fix maveriknight's custom item

### DIFF
--- a/config/custom_items.txt
+++ b/config/custom_items.txt
@@ -784,9 +784,7 @@ item_desc: A modified bandolier, attached are three brightly coloured pouches an
 ckey: maveriknight
 character_name: Kristen Osterweis
 item_path: /obj/item/device/camera
-item_name: Old Camera
+item_name: old camera
 item_icon: osterweis_oldcamera
 item_desc: An old Ward-Takahashi brand personal camera, with a built-in photo developer. Its edges look worn from use. The silver paint on the bottom has been worn away to reveal simple grey plastic beneath, but it looks like the camera still works.
-req_titles: Passenger
 }
-


### PR DESCRIPTION
Custom item spawning is not respecting alt titles. It's just a camera, anyway. It doesn't need to be job restricted.

Fixes https://github.com/Baystation12/Baystation12/issues/19205