### PR TITLE
Small fix to an item name

### DIFF
--- a/config/custom_items/suit_kits/zenithstar-construction.json
+++ b/config/custom_items/suit_kits/zenithstar-construction.json
@@ -1,7 +1,7 @@
 {
 	"ckey" :            "zenithstar",
 	"character_name" :  "Nikolas Jenkins",
-	"item_name" :       "excavation",
+	"item_name" :       "construction",
 	"item_desc" :       "An engineering voidsuit. A stitched label on the chest reads 'Jenkins Construction'.",
 	"item_icon_state" : "construction",
 	"item_path" :       "/obj/item/device/kit/suit"


### PR DESCRIPTION
The name got changed I believe when each item was split into an individual file. Just changes it back to construction instead of excavation.